### PR TITLE
Add resetSheet function for Google Sheet reset

### DIFF
--- a/script.js
+++ b/script.js
@@ -84,6 +84,16 @@ function clearPurchases(){
   }
 }
 
+function resetSheet(){
+  if(!confirm('Use a new Google Sheet?')) return;
+  SPREADSHEET_ID = null;
+  localStorage.removeItem('userSheetId');
+  setSyncStatus('Sheet reset. Please sign in again','err');
+  const btn = document.getElementById('googleSignInBtn');
+  if (btn) btn.style.display = '';
+}
+window.resetSheet = resetSheet;
+
 function initGapi() {
   return new Promise((resolve,reject)=>{
     if(!window.gapi) return reject(new Error("gapi not loaded"));


### PR DESCRIPTION
## Summary
- Add `resetSheet` helper to unlink the stored Google Sheet and show sign-in prompt
- Expose `resetSheet` globally for HTML button usage

## Testing
- `node --check script.js && echo "Syntax OK"`


------
https://chatgpt.com/codex/tasks/task_e_68aa22ebf2d0832b857da8579bfc0bc3