### PR TITLE
Refactor ensureSignedIn to await token via callback

### DIFF
--- a/script.js
+++ b/script.js
@@ -122,8 +122,20 @@ async function googleSignIn() {
 async function ensureSignedIn(){
   const token = gapi.client.getToken();
   if (token?.access_token) return;
-  tokenClient.requestAccessToken({ prompt:'' });
-  await new Promise(r=>setTimeout(r,700));
+  await new Promise((resolve, reject) => {
+    tokenClient.requestAccessToken({
+      prompt: '',
+      callback: (resp) => {
+        if (resp.error || !resp.access_token) {
+          reject(resp.error ? new Error(resp.error) : new Error('No token'));
+          return;
+        }
+        gapi.client.setToken({ access_token: resp.access_token });
+        document.getElementById('googleSignInBtn').style.display = 'none';
+        resolve();
+      }
+    });
+  });
 }
 
 async function ensureSheetInitialized(){


### PR DESCRIPTION
## Summary
- Refactor ensureSignedIn to wrap tokenClient.requestAccessToken in a Promise and resolve on callback token receipt
- Remove timeout polling and set token & hide sign-in button when resolved

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aa234e8f7c832baabce90948f603f9