### PR TITLE
Remove Google Sheet creation

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
       <button onclick="addPurchase()">Add Purchase</button>
       <button class="clear-btn" onclick="clearPurchases()">Clear All</button>
       <div id="syncStatus" class="sync-status">Not synced yet</div>
-      <button class="linkish" onclick="resetSheet()">Use a new Google Sheet</button>
+      <button class="linkish" onclick="promptSheetId()">Set Google Sheet ID</button>
     </div>
   </header>
 


### PR DESCRIPTION
## Summary
- Replace reset logic with prompt to set an existing Google Sheet ID
- Require existing sheet ID instead of auto-creating a new one

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aa24e2c4ec832b967cf44430420383